### PR TITLE
build(docker): Introduce the repo-cmd.py script and provide core Ubun…

### DIFF
--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -1,0 +1,16 @@
+---
+name: Docker Image Builder
+
+on:
+    workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Echo building message
+      run: echo "Building the Docker image"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,129 @@
-venv
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+
 # list of external repos cloned by west
 devops/docker-wrapper

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,29 @@ repos:
     - push
   repo: https://github.com/commitizen-tools/commitizen
   rev: v3.29.1
+
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.8.0
+  hooks:
+    - id: shellcheck
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      name: isort (python)
+      args: ["--profile", "black", --line-length=99]
+
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+    - id: black
+      language_version: python3
+
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
+  hooks:
+    - id: flake8
+      exclude: |
+        (?x) (
+        )

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
 
+REPO_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # Create virtual environment and install requirements
 venv/bin/activate: requirements.wrspc.txt ## create virtual environment and install requirements
 	python3 -m venv venv
@@ -8,6 +10,20 @@ venv/bin/activate: requirements.wrspc.txt ## create virtual environment and inst
 .PHONY: venv
 venv: venv/bin/activate ## create virtual environment and install requirements
 
+dev-container: venv ## Create a development container
+	mkdir -p $(REPO_DIR)/.local
+	. venv/bin/activate && ./repo-cmds.py docker prompt \
+		--network=host \
+		--volume $(REPO_DIR)/.local:$$HOME/.local \
+		ubuntu_2204_dev
+
+
+dev-container-gpu: venv ## Create a development container with GPU support
+	mkdir -p $(REPO_DIR)/.local
+	. venv/bin/activate && ./repo-cmds.py docker prompt \
+		--network host \
+		--volume $(REPO_DIR)/.local:$$HOME/.local \
+		ubuntu_2204_cuda_dev
 
 # HELP
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -79,5 +79,45 @@ make venv
 # Activate the workspace venv
 sourve venv/bin/activate
 
+# Start a development container for cpu development
+make dev-container
 
+# Start a GPU development container
+make dev-container-gpu
+
+```
+
+## Interacting with the repo CLI tool
+
+As part of the repo we have a CLI tool that helps automating a
+number of tasks. Currently it wraps and automates our common tasks
+when interacting with docker.
+
+To use the CLI tool, you can use the following commands:
+
+```bash
+# Activate the workspace venv
+sourve venv/bin/activate
+
+# List the supported sub-commands
+./repo-cmds.py --help
+
+# List the docker sub-commands
+./repo-cmds.py docker --help
+
+# The CLI provides commands to build, pull, push the docker images
+# start a prompt inside or run a command inside the docker container and then edit.
+
+# To start a prompt use the prmpt sub-command followed by the name of the docker image
+# to use
+./repo-cmds.py docker prompt ubuntu_2204_dev
+
+# To run command inside the docker container, do something like the following,
+# where after the docker sub-command we use the name of the docker image
+# to use followed by the command to run inside the container
+
+./repo-cmds.py docker ubuntu_2204_base "echo I am inside Docker"
+....
+echo I am inside Docker
+I am inside Docker
 ```

--- a/ci-docker-images/ubuntu/Docker/Dockerfile
+++ b/ci-docker-images/ubuntu/Docker/Dockerfile
@@ -1,0 +1,59 @@
+ARG INIT_IMAGE
+
+FROM ${INIT_IMAGE} as base
+
+ARG BASE_SETUP_SCRIPT
+
+# Generic dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt-get update && apt-get install --no-install-recommends -y \
+    apt-utils \
+    bash-completion \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    gosu \
+    less \
+    lsb-release \
+    sudo \
+    screen \
+    ssh \
+    tmux \
+    tzdata \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY ./entrypoint.sh  /
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+FROM base AS dev_base
+
+# The following scripts have been taken from the TVM build system
+
+COPY install/ubuntu_install_core.sh /tmp/install/ubuntu_install_core.sh
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  bash /tmp/install/ubuntu_install_core.sh
+
+
+FROM dev_base AS dev
+
+# Install github cli
+
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  mkdir -p -m 755 /etc/apt/keyrings && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt update \
+  && apt install gh -y
+
+
+ENV PATH=$PATH:/usr/local/minio-binaries/

--- a/ci-docker-images/ubuntu/Docker/entrypoint.sh
+++ b/ci-docker-images/ubuntu/Docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "$SRC_DIR" ]]; then
+    echo Undefined macro "$SRC_DIR"
+    exit 1
+fi;
+
+cd "$SRC_DIR"
+
+PATH=$PATH:$SRC_DIR/bin
+# If prompt defined drop the user to the prompt
+if [[ -n "$PROMPT" ]]; then
+    exec bash
+    exit 0;
+fi;
+
+echo "$@"
+# Execute the rest of the commands as is
+exec bash -c "$@"

--- a/ci-docker-images/ubuntu/Docker/install/ubuntu2204_install_llvm.sh
+++ b/ci-docker-images/ubuntu/Docker/install/ubuntu2204_install_llvm.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+# shellcheck disable=SC2129
+
+echo deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main\
+     >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main\
+     >> /etc/apt/sources.list.d/llvm.list
+
+echo deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main\
+     >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy main\
+     >> /etc/apt/sources.list.d/llvm.list
+
+wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+apt-get update && apt-get install -y --no-install-recommends \
+     llvm-17 llvm-17-dev \
+     clang-17 libclang-17-dev libpolly-17-dev libzstd-dev

--- a/ci-docker-images/ubuntu/Docker/install/ubuntu_install_core.sh
+++ b/ci-docker-images/ubuntu/Docker/install/ubuntu_install_core.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+# Used for debugging RVM build
+set -x
+set -o pipefail
+
+# install libraries for building c++ core on ubuntu
+apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    ccache \
+    curl \
+    g++ \
+    gdb \
+    git \
+    graphviz \
+    libcurl4-openssl-dev \
+    libopenblas-dev \
+    libssl-dev \
+    libtinfo-dev \
+    libz-dev \
+    lsb-core \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python-is-python3 \
+    python3-pip \
+    make \
+    ninja-build \
+    parallel \
+    pkg-config \
+    sudo \
+    texinfo \
+    unzip \
+    wget \

--- a/ci-docker-images/ubuntu/docker_wrapper_extensions.py
+++ b/ci-docker-images/ubuntu/docker_wrapper_extensions.py
@@ -1,0 +1,220 @@
+"""ubuntu_base docker image"""
+
+import grp
+import hashlib
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+import docker_wrapper
+
+logger = logging.getLogger(__name__)
+
+
+class Ubuntu2204(docker_wrapper.DockerImage):
+    """Ubuntu 22.04 base docker image
+
+    Args:
+        docker_wrapper (_type_): Parent class
+    """
+
+    NAME = "ubuntu_2204_base"
+    TAG_PREFIX = "base"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.corrected_name = self.NAME.replace(f"_{self.TAG_PREFIX}", "")
+        self.repo_name = f"{self.corrected_name}"
+        self.docker_folder = os.path.realpath(
+            os.path.join(os.path.realpath(__file__), "../Docker")
+        )
+        self._enable_docker = False
+        self._enable_kvm = False
+        self.init_image = "ubuntu:22.04"
+        self.stage = "base"
+
+    @property
+    def image_tag(self) -> str:
+        """Return the tag of the image
+
+        If the image has an explicit numeric version return that, else
+        return the first 10 characters of the image hash.
+
+        Returns:
+            str: Return string to be used at the image tag.
+        """
+        suffix = super().image_tag
+        return f"{self.TAG_PREFIX}_{suffix}"
+
+    @property
+    def tagged_name(self) -> str:
+        """Return the tuple <IMAGE_NAME>:<IMAGE_TAG>
+
+        Returns:
+            str: String result
+        """
+        return f"{self.repo_name}:{self.image_tag}"
+
+    @property
+    def image_url(self) -> str:
+        """Return the full image URL, that is the
+            <REPO_URL>/<IMAGE_NAME>:<IMAGE_TAG>
+
+        Returns:
+            str: String result
+        """
+        if not self.repo_url:
+            return self.tagged_name
+
+        return f"{self.repo_url}{self.tagged_name}"
+
+    def build_image(
+        self,
+        aws_region: str = "",
+        force: bool = False,
+        try_pull: bool = True,
+        platform: Optional[List[str]] = ["linux/amd64"],
+    ) -> None:
+        """Build the image
+
+        Build any other images we depend on
+
+        Args:
+            aws_region (str, optional): AWS region to login to.
+            force_build (bool, optional): Iff True then build the image regardless.
+                Defaults to False.
+            try_pull (bool, optional): Iff True then try to pull the image from the
+                docker registry.
+            target (str, optional): Docker image build stage to build
+        """
+        image_url = self.image_url
+        ci_runner = False
+        if self.image_exists(image_url) and not force:
+            logger.info(f"Image: {image_url} already exists, not rebuilding")
+            return
+        elif try_pull and not force:
+            logger.info(f"Try pulling image {image_url}")
+            try:
+                self.pull()
+                return
+            except Exception as e:
+                logger.info(f"Failed to pull image {image_url} with error: {e}")
+
+        cmd = [
+            "DOCKER_BUILDKIT=1",
+            "docker",
+            "buildx",
+            "build",
+            "--target",
+            self.stage,
+            "--build-arg",
+            f"INIT_IMAGE={self.init_image}",
+        ]
+        cmd += [
+            "-t",
+            image_url,
+            "--load",
+        ]
+        if platform:
+            cmd += ["--platform", ",".join(platform)]
+        # Build context is the docker folder
+        cmd += ["."]
+        # Avoid logging by default to avoid leaking sensitive information
+        cmd_str = " ".join(cmd)
+        print(f"Running command: {' '.join(cmd)}")
+        subprocess.check_call(cmd_str, shell=True, cwd=self.docker_folder)
+
+    @property
+    def image_hash(self) -> str:
+        """Compute the hash of the derived image
+
+        To capture correctly any possible changes to the parent image as well,
+        the image hash is the combined hash of the "base" image that is passed
+        as a build arguments, any other build argument value, and the hash of
+        the Docker folder of the derived image. The build arguments are passed
+        as a dictionary to the Docker build command, and the keys are sorted
+        alphabetically to ensure that the hash is the same regardless of the
+        order of the build arguments. The hash of the Docker folder is computed
+        by recursively hashing all files in the folder, and the hash of the
+        folder is the hash of the concatenated hashes of all files in the
+        folder.
+
+        Returns:
+            str: Returned hash value
+        """
+        this_image_hash = self.folder_hash(self.docker_folder)
+        logging.debug(f"This image hash {this_image_hash}")
+        hash_object = hashlib.sha1(
+            this_image_hash.encode("utf8") + self.init_image.encode("utf8")
+        ).hexdigest()
+        return hash_object
+
+
+class Ubuntu2204DevBase(Ubuntu2204):
+    """Ubuntu 22.04 Dev base docker image
+
+    Args:
+        docker_wrapper (_type_): Parent class
+    """
+
+    NAME = "ubuntu_2204_dev_base"
+    TAG_PREFIX = "dev_base"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.corrected_name = self.NAME.replace(f"_{self.TAG_PREFIX}", "")
+        self.repo_name = f"{self.corrected_name}"
+        self.docker_folder = os.path.realpath(
+            os.path.join(os.path.realpath(__file__), "../Docker")
+        )
+        self.stage = self.TAG_PREFIX
+
+
+class Ubuntu2204Dev(Ubuntu2204):
+    """Ubuntu 22.04 dev docker image"""
+
+    NAME = "ubuntu_2204_dev"
+    TAG_PREFIX = "dev"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.corrected_name = self.NAME.replace(f"_{self.TAG_PREFIX}", "")
+        self.repo_name = f"{self.corrected_name}"
+        self.docker_folder = os.path.realpath(
+            os.path.join(os.path.realpath(__file__), "../Docker")
+        )
+        self.stage = self.TAG_PREFIX
+
+
+class Ubuntu2204Cuda(Ubuntu2204):
+    """Ubuntu 22.04 Cuda base docker image
+
+    Args:
+        docker_wrapper (_type_): Parent class
+    """
+
+    NAME = "ubuntu_2204_cuda_dev"
+    TAG_PREFIX = "dev"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.corrected_name = self.NAME.replace(f"_{self.TAG_PREFIX}", "")
+        self.repo_name = f"{self.corrected_name}"
+        self.docker_folder = os.path.realpath(
+            os.path.join(os.path.realpath(__file__), "../Docker")
+        )
+        self._enable_docker = False
+        self._enable_kvm = False
+        self.init_image = "nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04"
+        self.stage = "dev"
+
+    def get_docker_run_args(self) -> List[str]:
+        """Get the docker arguments to use when running the image
+
+        Returns:
+            List[str]: List of docker arguments
+        """
+        return ["--gpus", "all"]

--- a/environment-cfg.yml
+++ b/environment-cfg.yml
@@ -1,0 +1,8 @@
+---
+# This repo can execute/build under different compute environments
+# e.g. AWS, or a local server etc
+# This file contains configuration information regarding the
+# diff
+local:
+  docker_registry_prefix: ghcr.io/idoudali/
+  docker_login_command: "echo Run local, using your GitHub token \"echo $CR_PAT | docker login ghcr.io -u GITHUB_USERNAME --password-stdin\" and follow the prompt"

--- a/repo-cmds.py
+++ b/repo-cmds.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+import socket
+from pathlib import Path
+
+import docker_wrapper
+import typer
+import yaml
+
+REPO_DIR = Path(__file__).parent.absolute()
+CONFIG_FILE_PATH = REPO_DIR / "environment-cfg.yml"
+ENV_CONFIG = {}
+
+
+def get_domain():
+    return socket.getfqdn()
+
+
+def read_config_file(file_path):
+    with open(file_path, "r") as file:
+        config_data = yaml.safe_load(file)
+    return config_data
+
+
+if __name__ == "__main__":
+
+    all_config_data = read_config_file(CONFIG_FILE_PATH)
+
+    app = typer.Typer()
+
+    @app.callback()
+    def main(
+        env_name: str = typer.Option("", help="Environment name"),
+    ):
+        global ENV_CONFIG
+        if env_name:
+            ENV_CONFIG = all_config_data[env_name]
+        else:
+            domain = get_domain()
+            if "ec2" in domain:
+                ENV_CONFIG = all_config_data["AWS"]
+            else:
+                ENV_CONFIG = all_config_data["local"]
+        docker_wrapper.set_env_config(ENV_CONFIG)
+
+    app.add_typer(
+        docker_wrapper.create_cli(
+            image_dir=REPO_DIR / "ci-docker-images", env_config_arg=ENV_CONFIG
+        ),
+        name="docker",
+    )
+
+    app()


### PR DESCRIPTION
…tu Docker Images

This commit:

* Updates the gitignore file with the list of possible python artifacts that we should ignore
* Adds python related pre-commit hookds
* Adds in the Makefile helper targets to create dev-containers based on the infrastructure added in this commit.
* Adds the fodler ci-docker-images that contains the infrastructure to build Ubuntu-22.04 docker images with and without GPU support
* Adds thes the repo-cmds.py script that calls docker-wrapper and provides a CLI interface to interract with Docker and simplify common Docker actions
* Updates the README.md with instructions how to use the above tools and flows.
* Adds the environment-cfg.yml file that contains options passed to repo-cmds.py and specifies configuration parameters specific to the current compute environment.