### PR TITLE
ci(docker): Implement the github workflow that builds our docker images

### DIFF
--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -1,16 +1,64 @@
 ---
+# This workflow is inspired by https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+# We cannot use the docker/build-push-action as that action does not
+# tie with our custom flow for building docker images
+# FIXME in the future we should consider how to use the docker/attest-build-provenance
+# action so that we can correctly create a proper provenance for the
+# generated docker images.
 name: Docker Image Builder
 
 on:
     workflow_dispatch:
 
+
+# Defines two custom environment variables for the workflow.
+# These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ubuntu_22.04_dev
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build:
+  build-and-push-image:
     runs-on: ubuntu-latest
-
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Echo building message
-      run: echo "Building the Docker image"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using
+      # the account and password that will publish the packages. Once published, the packages
+      # are scoped to the account defined here.
+      - name: Setup Python
+        uses: actions/setup-python@v5.2.0
+        with:
+          python-version: '3.10'
+      - name: Install west
+        run: |
+            python -m pip install --upgrade pip
+            pip install west
+      - name: Update workspace
+        run: |
+            west update
+      - name: Build core venv
+        run: |
+            make venv
+      - name: Build the docker image
+        run: |
+            source venv/bin/activate \
+            && ./repo-cmds.py docker build ${{ env.IMAGE_NAME }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push the docker image
+        run: |
+            source venv/bin/activate \
+            && ./repo-cmds.py docker push ${{ env.IMAGE_NAME }}

--- a/ci-docker-images/ubuntu/docker_wrapper_extensions.py
+++ b/ci-docker-images/ubuntu/docker_wrapper_extensions.py
@@ -21,7 +21,7 @@ class Ubuntu2204(docker_wrapper.DockerImage):
         docker_wrapper (_type_): Parent class
     """
 
-    NAME = "ubuntu_2204_base"
+    NAME = "ubuntu_22.04_base"
     TAG_PREFIX = "base"
 
     def __init__(self, **kwargs) -> None:
@@ -160,7 +160,7 @@ class Ubuntu2204DevBase(Ubuntu2204):
         docker_wrapper (_type_): Parent class
     """
 
-    NAME = "ubuntu_2204_dev_base"
+    NAME = "ubuntu_22.04_dev_base"
     TAG_PREFIX = "dev_base"
 
     def __init__(self, **kwargs) -> None:
@@ -176,7 +176,7 @@ class Ubuntu2204DevBase(Ubuntu2204):
 class Ubuntu2204Dev(Ubuntu2204):
     """Ubuntu 22.04 dev docker image"""
 
-    NAME = "ubuntu_2204_dev"
+    NAME = "ubuntu_22.04_dev"
     TAG_PREFIX = "dev"
 
     def __init__(self, **kwargs) -> None:
@@ -196,7 +196,7 @@ class Ubuntu2204Cuda(Ubuntu2204):
         docker_wrapper (_type_): Parent class
     """
 
-    NAME = "ubuntu_2204_cuda_dev"
+    NAME = "ubuntu_22.04_cuda_dev"
     TAG_PREFIX = "dev"
 
     def __init__(self, **kwargs) -> None:


### PR DESCRIPTION
This commit:
1. Fixes the docker image names to be ubuntu-22.04
2. Populates the docker-image-builder.yml workflow with a job that builds the ubuntu_22.04_dev docker image and pushes it as an artifact to the GitHub docker registry