### PR TITLE
build(google-test): Add support for building google-test from source

### DIFF
--- a/.github/workflows/checkin-tests.yml
+++ b/.github/workflows/checkin-tests.yml
@@ -49,3 +49,7 @@ jobs:
         run: |
             source venv/bin/activate \
             && ./repo-cmds.py docker ${{ env.IMAGE_NAME }} "make configure-Release"
+      - name: Build google-test
+        run: |
+            source venv/bin/activate \
+            && ./repo-cmds.py docker ${{ env.IMAGE_NAME }} "cd build-Release && ninja google-test"

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ build-*
 
 # list of external repos cloned by west
 devops/docker-wrapper
+libs/google-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,9 @@ include(cmake/chroot.cmake)
 # across different CMake files
 set(WORKSPACES_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/workspace)
 
+# Name of the workspace that will hold any example-cpp related tools
+set(EXAMPLE_CPP_WS_NAME example-cpp)
+
+include(workspace/pyvenv-setup.cmake)
+add_subdirectory("libs")
 add_subdirectory("workspace")

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ build-$(build_type): configure-$(build_type) ## Build the $(build_type) build
 	cd build-$(build_type) && ninja -v -j `nproc` -l `nproc` all
 	cd build-$(build_type) && cp .ninja_log .ninja_log.build
 
+.PHONY: targets-$(build_type)
+targets-$(build_type): configure-$(build_type) ## List the targets for the $(build_type) build
+	@ cd build-$(build_type) && ninja help | grep phony | sort
+
 endef
 
 $(foreach build,$(BUILD_TYPES_ARGS),$(eval $(call BUILD_template,$(build))))
@@ -67,6 +71,7 @@ help:
 	@ for build in $(BUILD_TYPES_ARGS); do \
 		echo "configure-$$build: ## Configure the $$build build" | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'; \
 		echo "build-$$build: ## Build the $$build build" | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'; \
+		echo "targets-$$build: ## List the targets of $$build build" | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'; \
 	  done
 
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ make build-Release
 cd build-Release
 # List available targets
 ninja help
+# or try to build a target in Makefile that will print only the
+# phony targets in Ninja (if that suits you.)
+make targets-Release
 # Then try your luck :)
 ```
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Set the path to the external project
+set(EXTERNAL_PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/google-test)
+
+# Target that builds the pyvenv/chroot where we want to install google-test
+# inside
+set(WRSPC_BUILD_TARGET ${EXAMPLE_CPP_WS_NAME}-pyvenv-build)
+
+# Get the installation directory of the python venv
+get_property(
+  EXAMPLE_CPP_WS_NAME
+  TARGET ${WRSPC_BUILD_TARGET}
+  PROPERTY pyvenv-dir
+)
+
+# Add the external project
+include(ExternalProject)
+ExternalProject_Add(
+  google-test
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/google-test
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/google-test
+  CMAKE_ARGS -G Ninja #
+             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} #
+             -DCMAKE_INSTALL_PREFIX=${EXAMPLE_CPP_WS_NAME} #
+  DEPENDS #
+          ${WRSPC_BUILD_TARGET} #
+)

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,3 @@
+# Libs
+
+This folder contains a number of libs that we build from source

--- a/west.yml
+++ b/west.yml
@@ -13,3 +13,10 @@ manifest:
     url: https://github.com/idoudali/DockerWrapper.git
     path: devops/docker-wrapper
     revision: 36b69491d41b1156af01101dcb45285043893211
+
+  # libs
+  - name: google-test
+    url: https://github.com/google/googletest.git
+    path: libs/google-test
+    submodules: true
+    revision: v1.15.2

--- a/workspace/CMakeLists.txt
+++ b/workspace/CMakeLists.txt
@@ -1,12 +1,8 @@
 # Workspace setup
 
-set(PYVENV_NAME example)
-
-pyvenv_create(NAME ${PYVENV_NAME})
-
 pyvenv_install_requirements(
   NAME
-  ${PYVENV_NAME} #
+  ${EXAMPLE_CPP_WS_NAME} #
   REQUIREMENTS_FILES #
   ${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt
   ${CMAKE_CURRENT_SOURCE_DIR}/requirements.jupyter.txt

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -11,7 +11,7 @@ you will notice that we are making use of the `pyvenv_create` and
 
 Currently, the following virtual environments are created:
 
-* `example`: toy python-venv used for demo purposes.
+* `example-cpp`: chroot/pyvenv folder where we install a number of binary libraries.
 
 ### Build Commands
 

--- a/workspace/pyvenv-setup.cmake
+++ b/workspace/pyvenv-setup.cmake
@@ -1,0 +1,14 @@
+# Workspace setup
+#
+# This files contains the creation step of the chroot/pyvevn workspaces.
+# This file is to be included by the top-level CMakeLists.txt file of the folder
+# before we start building the different components of the project.
+# CMake parses the files in the order they are included, so we need to create
+# the target that creates the pyvenv first, before we introduce any other
+# components that depend on it and will install files inside the chroot/pyvenv.
+#
+
+pyvenv_create(
+  NAME ${EXAMPLE_CPP_WS_NAME} PYVENV_DIR
+  ${WORKSPACES_BINARY_DIR}/${EXAMPLE_CPP_WS_NAME}
+)


### PR DESCRIPTION
This commit:

* Checks out the google-test repo by adding it to the west.yml file
* Renames the "example" chroot environment to example-cpp
* Addresses build-dependency issues, where it splits the targets that create the skeleton of the pyvenv from the original CMakeLists.txt file under workspaces. This is necessary so that we can have targets like llama-cpp that can install their artifacts inside the pyvenv. For this reason the build-target and directory of the pyvenv need to be known by the target that builds google-test.
* Add helper Makefile command that lists all ninja targets of interest
* Update the documentation where necessary.
* Update the check-in CI job to build the google-test target